### PR TITLE
Add condition to requirements for typing package (python < 3.5)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,6 @@ pyjwt>=1.6.4,<2.1.0
 PyYAML>=3.12,<5.5.0
 requests>=2.20.0,<2.26.0
 six>=1.13.0,<1.16.0
-typing>=3.6.4,<3.8.0
+typing>=3.6.4,<3.8.0 ; python_version < '3.5'
 urllib3>=1.21.1,<1.27.0
 virtualenv>=16,<21


### PR DESCRIPTION
- According to the maintainer of the typing package, it is recommended
  to use the typing package with condition for python version since
  for python3.5 and later typing package is useless (as it is in the
  stdlib).
- Typing package can cause some issues so NOT installing it can solve
  some of them.
  
Some examples of similar problems with `typing` package:
https://stackoverflow.com/questions/55833509/attributeerror-type-object-callable-has-no-attribute-abc-registry