### PR TITLE
Support private repos from requirements.txt file

### DIFF
--- a/clearml_agent/external/requirements_parser/parser.py
+++ b/clearml_agent/external/requirements_parser/parser.py
@@ -47,8 +47,9 @@ def parse(reqstr, cwd=None):
                 line.startswith('--extra-index-url') or \
                 line.startswith('--no-index'):
             _, extra_index = line.split()
-            PIP_EXTRA_INDICES.append(extra_index)
-            print(f"appended {extra_index} to list of extra pip indices")
+            if extra_index not in PIP_EXTRA_INDICES:
+                PIP_EXTRA_INDICES.append(extra_index)
+                print(f"appended {extra_index} to list of extra pip indices")
             continue
         elif line.startswith('-Z') or line.startswith('--always-unzip'):
             warnings.warn('Unused option --always-unzip. Skipping.')

--- a/clearml_agent/external/requirements_parser/parser.py
+++ b/clearml_agent/external/requirements_parser/parser.py
@@ -1,6 +1,8 @@
 import os
 import warnings
 
+from clearml_agent.definitions import PIP_EXTRA_INDICES
+
 from .requirement import Requirement
 
 
@@ -44,7 +46,9 @@ def parse(reqstr, cwd=None):
                 line.startswith('-i') or line.startswith('--index-url') or \
                 line.startswith('--extra-index-url') or \
                 line.startswith('--no-index'):
-            warnings.warn('Private repos not supported. Skipping.')
+            _, extra_index = line.split()
+            PIP_EXTRA_INDICES.append(extra_index)
+            print(f"appended {extra_index} to list of extra pip indices")
             continue
         elif line.startswith('-Z') or line.startswith('--always-unzip'):
             warnings.warn('Unused option --always-unzip. Skipping.')


### PR DESCRIPTION
This PR will allow the agent to fetch packages from an extra private repo that are defined in the `requirements.txt`.

```
--extra-index-url https://pypi.dev.promaton.ai/simple

# packages go below
```

This is especially useful when triggering jobs through the ClearML UI. If you need private packages you can just add the extra index urls in the UI instead of having to reconfigure the agent.

<img width="933" alt="image" src="https://user-images.githubusercontent.com/6594531/167438431-918b8e5f-8b12-4f5b-a13f-b20bb031053d.png">
