### PR TITLE
Use correct Python version in Poetry init

### DIFF
--- a/clearml_agent/commands/worker.py
+++ b/clearml_agent/commands/worker.py
@@ -3569,8 +3569,8 @@ class Worker(ServiceCommandSection):
                     executable_version, executable_version_suffix, executable_name = \
                         self.find_python_executable_for_version(def_python_version)
 
-                self._session.config.put("agent.default_python", executable_version_suffix)
-                self._session.config.put("agent.python_binary", executable_name)
+            self._session.config.put("agent.default_python", executable_version_suffix)
+            self._session.config.put("agent.python_binary", executable_name)
 
         venv_dir = Path(venv_dir) if venv_dir else \
             Path(self._session.config["agent.venvs_dir"], executable_version_suffix)

--- a/clearml_agent/helper/package/poetry_api.py
+++ b/clearml_agent/helper/package/poetry_api.py
@@ -90,8 +90,8 @@ class PoetryConfig:
         if not self._initialized:
             # use correct python version -- detected in Worker.install_virtualenv() and written to
             # session
-            if self.session.config.get('agent.python_binary', None) is not None:
-                self._python = self.session.config.get('agent.python_binary')
+            if self.session.config.get("agent.python_binary", None) is not None:
+                self._python = self.session.config.get("agent.python_binary")
 
             if self.session.config.get("agent.package_manager.poetry_version", None) is not None:
                 version = str(self.session.config.get("agent.package_manager.poetry_version"))

--- a/clearml_agent/helper/package/poetry_api.py
+++ b/clearml_agent/helper/package/poetry_api.py
@@ -90,7 +90,7 @@ class PoetryConfig:
         if not self._initialized:
             # use correct python version -- detected in Worker.install_virtualenv() and written to
             # session
-            if self.session.config.get("agent.python_binary", None) is not None:
+            if self.session.config.get("agent.python_binary", None):
                 self._python = self.session.config.get("agent.python_binary")
 
             if self.session.config.get("agent.package_manager.poetry_version", None) is not None:

--- a/clearml_agent/helper/package/poetry_api.py
+++ b/clearml_agent/helper/package/poetry_api.py
@@ -40,11 +40,11 @@ def prop_guard(prop, log_prop=None):
 
 class PoetryConfig:
 
-    def __init__(self, session, interpreter=None):
+    def __init__(self, session):
         # type: (Session, str) -> None
         self.session = session
         self._log = session.get_logger(__name__)
-        self._python = interpreter or sys.executable
+        self._python = sys.executable  # default, overwritten from session config in initialize()
         self._initialized = False
 
     @property
@@ -88,6 +88,11 @@ class PoetryConfig:
     @_guard_enabled
     def initialize(self, cwd=None):
         if not self._initialized:
+            # use correct python version -- detected in Worker.install_virtualenv() and written to
+            # session
+            if self.session.config.get('agent.python_binary', None) is not None:
+                self._python = self.session.config.get('agent.python_binary')
+
             if self.session.config.get("agent.package_manager.poetry_version", None) is not None:
                 version = str(self.session.config.get("agent.package_manager.poetry_version"))
 


### PR DESCRIPTION
It seems that the Poetry initialization always uses the system's default Python version, and not the one requested for the task.

This causes issues because it results in packages being installed with the wrong version of Pip (when the main script execution starts, poetry is run with the correct Python version, i.e., the requested one, and it crashes).

With this patch, it works:
* Target Python version (mine: 3.7) installed on local machine and worker (both have system default of 3.10)
* Local machine: using an environment with Poetry installed in Python 3.7
* In pyproject.toml: `python = "^3.7.0"`
* Locally: `poetry env use 3.7` and `poetry install`, then add `poetry.lock` to VCS
* `poetry run python main_which_will_exec_remotely.py`