### PR TITLE
Fix FileNotFoundException crash in find_python_executable_for_version…

### DIFF
--- a/clearml_agent/commands/worker.py
+++ b/clearml_agent/commands/worker.py
@@ -3320,8 +3320,8 @@ class Worker(ServiceCommandSection):
                         stderr=subprocess.STDOUT
                     )
                 except subprocess.CalledProcessError as ex:
-                    # Windows return 9009 code and suggest to install Python from Windows Store
-                    if ex.returncode == 9009:
+                    # Windows returns 9009 code and suggests to install Python from Windows Store
+                    if is_windows_platform() and ex.returncode == 9009:
                         self.log.debug("version not found: {}".format(ex))
                     else:
                         self.log.warning("error getting %s version: %s", executable, ex)

--- a/clearml_agent/commands/worker.py
+++ b/clearml_agent/commands/worker.py
@@ -3320,7 +3320,14 @@ class Worker(ServiceCommandSection):
                         stderr=subprocess.STDOUT
                     )
                 except subprocess.CalledProcessError as ex:
-                    self.log.warning("error getting %s version: %s", executable, ex)
+                    # Windows return 9009 code and suggest to install Python from Windows Store
+                    if ex.returncode == 9009:
+                        self.log.debug("version not found: {}".format(ex))
+                    else:
+                        self.log.warning("error getting %s version: %s", executable, ex)
+                    continue
+                except FileNotFoundError as ex:
+                    self.log.debug("version not found: {}".format(ex))
                     continue
 
                 if not default_python:


### PR DESCRIPTION
# Related Issue \ discussion
#164

# Patch Description
Added FileNotFoundError handler and handler for 9009 error code (file not found) while finding a Python executable by version. The environment can't be recreated in windows without it.
1. For example, consider searching for version 3.11 in python3.11 environment in the current implementation.
In the first iteration, python3.11 will not be found and FileNotFoundError will be thrown (it's OSError and not CalledProcessError). So the exception will be passed to install_virtualenv function.
2. install_virtualenv function will print a strange message "Warning: could not locate requested Python version 3.11, reverting to version 3.11" and call again find_python_executable_for_version to find 3.11 executable. But find_python_executable_for_version will throw FileNotFoundError again and install_virtualenv will be terminated.
3. The executable file is called "python" on Windows (not python3). But when you call "python3", Windows return 9009 error code instead of FileNotFoundException and kindly suggests installing Python from its store. So additional check for the 9009 error code is needed.

# Environment
Windows