### PR TITLE
Fix k8s glue error

### DIFF
--- a/clearml_agent/glue/k8s.py
+++ b/clearml_agent/glue/k8s.py
@@ -490,7 +490,6 @@ class K8sIntegration(Worker):
                             "task": task_id,
                             "queue": self.k8s_pending_queue_id,
                             "status_reason": "k8s pending scheduler",
-                            "update_execution_queue": False,
                         }
                     )
                     if res.ok:


### PR DESCRIPTION
From `clearml-agent>=1.9.3`, there is an error while using ClearML Agent in Kubernetes

Error looks like:

`ERROR: Could not push back task [<>] to k8s pending queue k8s_scheduler [<>], error: Validation error (Cannot skip setting execution queue for a task that is not enqueued or does not have execution queue set)`

It was mentioned in https://github.com/clearml/clearml-agent/issues/223

In `clearml-agent==1.9.2` and before, it was function https://clear.ml/docs/latest/docs/references/api/tasks#post-tasksenqueue with default parameter `update_execution_queue` (`true`), and it worked (https://github.com/clearml/clearml-agent/blob/v1.9.2/clearml_agent/glue/k8s.py#L469). This PR deletes setting `update_execution_queue` in `false` (so `update_execution_queue` will be `true` by default)