### PR TITLE
Handle `OSError` when checking for `is_file`

### DIFF
--- a/clearml_agent/commands/worker.py
+++ b/clearml_agent/commands/worker.py
@@ -3511,7 +3511,12 @@ class Worker(ServiceCommandSection):
                     task=task, vcs=vcs, execution_info=execution, repo_info=repo_info
                 )
             script_file = Path(directory) / execution.entry_point
-            if not script_file.is_file():
+
+            try:
+                is_file = script_file.is_file()
+            except OSError:
+                is_file = False
+            if is_file:
                 # try to parse with shlex
                 try:
                     script_file = Path(directory) / shlex.split(execution.entry_point)[0]

--- a/clearml_agent/commands/worker.py
+++ b/clearml_agent/commands/worker.py
@@ -3516,7 +3516,7 @@ class Worker(ServiceCommandSection):
                 is_file = script_file.is_file()
             except OSError:
                 is_file = False
-            if is_file:
+            if not is_file:
                 # try to parse with shlex
                 try:
                     script_file = Path(directory) / shlex.split(execution.entry_point)[0]


### PR DESCRIPTION
Fixes #260. 

Same logic of https://github.com/clearml/clearml-agent/pull/215.