### PR TITLE
Update psutil requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-psutil>=3.4.2,<7.1
+psutil>=3.4.2,<7.3
 urllib3>=1.21.1,<3
 virtualenv>=16,<21
 requests>=2.20.0,<2.33


### PR DESCRIPTION
Updates `psutil`'s upper bound to `<7.3`, to accommodate for the newest 7.2.2 version ([Pypi](https://pypi.org/project/psutil/)).

The goal with this PR is to remove the implicit `psutil<7.1` requirement bound that any projects depending on `clearml-agent` will have.