### PR TITLE
Remove explicit TLS protocol version

### DIFF
--- a/clearml_agent/backend_api/utils.py
+++ b/clearml_agent/backend_api/utils.py
@@ -1,5 +1,4 @@
 import logging
-import ssl
 import sys
 
 import requests
@@ -46,8 +45,7 @@ class TLSv1HTTPAdapter(HTTPAdapter):
     def init_poolmanager(self, connections, maxsize, block=False, **pool_kwargs):
         self.poolmanager = PoolManager(num_pools=connections,
                                        maxsize=maxsize,
-                                       block=block,
-                                       ssl_version=ssl.PROTOCOL_TLSv1_2)
+                                       block=block)
 
 
 def get_http_session_with_retry(


### PR DESCRIPTION
Hi, and thanks for developing the ClearML stack and agent.

From Python's documentation:
> Deprecated since version 3.6: OpenSSL has deprecated all version specific protocols. Use the default protocol PROTOCOL_TLS_SERVER or PROTOCOL_TLS_CLIENT with SSLContext.minimum_version and SSLContext.maximum_version instead.

Simply removing the explicit version for the TLS protocol works on my end.